### PR TITLE
Add debian to os.distro

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -20,9 +20,9 @@ os:
         platform: ANY
         version: ["5.0", "6.0", "7.0", "8.0"]
     Linux:
-        # Distinguish CentOS and AlmaLinux from other distributions, so packages
-        # built on other distributions are not downloaded there.
-        distro: [None, "centos", "almalinux"]
+        # Distinguish some distributions, so packages built on different
+        # distributions are not downloaded there.
+        distro: [None, "centos", "almalinux", "debian"]
     iOS:
         version: &ios_version
                  ["7.0", "7.1", "8.0", "8.1", "8.2", "8.3", "9.0", "9.1", "9.2", "9.3", "10.0", "10.1", "10.2", "10.3",


### PR DESCRIPTION
This prevents binary packages from being downloaded if they don't match the profile; adding because of glibc compatibility issues.