### PR TITLE
Use ecdc-conan-virtual

### DIFF
--- a/remotes.json
+++ b/remotes.json
@@ -1,13 +1,8 @@
 {
 	"remotes": [
 	 {
-		"name": "conancenter",
-		"url": "https://center.conan.io",
-		"verify_ssl": true
-	 },
-	 {
-		"name": "ecdc-conan-release",
-		"url": "https://artifactory.esss.lu.se/artifactory/api/conan/ecdc-conan-release",
+		"name": "ecdc-conan-virtual",
+		"url": "https://artifactory.esss.lu.se/artifactory/api/conan/ecdc-conan-virtual",
 		"verify_ssl": true
 	 }
 	]

--- a/remotes.txt
+++ b/remotes.txt
@@ -1,2 +1,1 @@
- conancenter https://center.conan.io true
- ecdc-conan-release https://artifactory.esss.lu.se/artifactory/api/conan/ecdc-conan-release true
+ ecdc-conan-virtual https://artifactory.esss.lu.se/artifactory/api/conan/ecdc-conan-virtual true


### PR DESCRIPTION
`ecdc-conan-virtual` is a collection of `ecdc-conan-release`, `ecdc-conan-external`, and `conan-center-remote` accessed through a single URL.
