### PR TITLE
profiles: add linux clang17 profile

### DIFF
--- a/profiles/linux_x86_64_clang17
+++ b/profiles/linux_x86_64_clang17
@@ -1,0 +1,15 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=clang
+compiler.version=17
+compiler.libcxx=libstdc++11
+build_type=Release
+
+[env]
+CC=/usr/bin/clang-17
+CXX=/usr/bin/clang++-17
+
+# Fix for implicit function declaration errors
+CFLAGS=-Wno-error=implicit-function-declaration
+CPPFLAGS=-Wno-error=implicit-function-declaration


### PR DESCRIPTION
I uploaded prebuilt binaries for this profile to `ecdc-conan-virtual`. That should significantly speed up build jobs.

There's also a ubuntu2204 image with clang17 preinstalled:
`registry.esss.lu.se/ecdc/ess-dmsc/docker-ubuntu2204-conan:1.1.0-dev.1`

just use `--profile=linux_x86_64_clang17` for your `conan install`